### PR TITLE
adding new interfaces for getting time sync status and setting time c…

### DIFF
--- a/interfaces/ITimeSync.h
+++ b/interfaces/ITimeSync.h
@@ -97,8 +97,8 @@ namespace Exchange {
         virtual void Register(INotification* notification) = 0;
         virtual void Unregister(INotification* notification) = 0;
 
-        virtual uint32_t GetStatus(TSStatus &status /*@out*/ );
-        virtual uint32_t SetConfiguration(const TimeSyncConfiguration &config, TSErrorDetail &status/* @out */);
+        virtual uint32_t GetStatus(TSStatus &status /*@out*/ ) const {return 0;};
+        virtual uint32_t SetConfiguration(const TimeSyncConfiguration& config /* @in */, TSErrorDetail&status/* @out */){return 0;};
 
         virtual uint32_t Synchronize() = 0;
         virtual void Cancel() = 0;

--- a/interfaces/ITimeSync.h
+++ b/interfaces/ITimeSync.h
@@ -97,8 +97,8 @@ namespace Exchange {
         virtual void Register(INotification* notification) = 0;
         virtual void Unregister(INotification* notification) = 0;
 
-        virtual uint32_t GetStatus(TSStatus &status /*out*/ ) const = 0;
-        virtual uint32_t SetConfiguration(const TimeSyncConfiguration &config, TSErrorDetail &status/* @out */) = 0;
+        virtual uint32_t GetStatus(TSStatus &status /*out*/ );
+        virtual uint32_t SetConfiguration(const TimeSyncConfiguration &config, TSErrorDetail &status/* @out */);
 
         virtual uint32_t Synchronize() = 0;
         virtual void Cancel() = 0;

--- a/interfaces/ITimeSync.h
+++ b/interfaces/ITimeSync.h
@@ -28,7 +28,65 @@ namespace Exchange {
     // This interface gives direct access to a time synchronize / update
     struct EXTERNAL ITimeSync : virtual public Core::IUnknown {
         enum { ID = ID_TIMESYNC };
+        
+        enum TSStatus: uint8_t {
+            TS_DISABLED = 0,
+            TS_UNSYNCHRONIZED,
+            TS_SYNCHRONIZED,
+            TS_ERROR
+        };
 
+        enum TSErrorDetail: uint8_t {
+            TS_OK = 0,
+            TS_FAIL,
+            TS_INVALID_CONFIGURATION
+        };
+
+        enum TSTransmissionMode: uint8_t {
+            TS_MODE_UNICAST = 0,
+            TS_MODE_BROADCAST,
+            TS_MODE_MULTICAST,
+            TS_MODE_MANYCAST
+        };
+        
+        struct TimeSyncConfiguration {
+            TSTransmissionMode mode; // Unicast / Broadcast / Multicast / Manycast
+            uint32_t port; // the port used to send NTP packets
+            uint32_t version; 
+            //Comma-separated list of strings. Points to a CSV list of NTP servers or pools. 
+            //A NTP server can either be specified as an IP address or a host name. 
+            //It is expected that the NTP client resolves multiple addresses which can change over time when ResolveAddresses is enabled.
+            std::string servers;
+            // When this option is enabled the NTP client must resolve the multiple addresses 
+            //associated with the host name(s) that are specified in the Servers field.
+            bool resolveAddresses;
+            // When ResolveAddresses is enabled, This parameter specifies the maximum number of IP addresses 
+            // that the NTP client can resolve. 0 means that all addresses must be resolved.
+            uint32_t resolveMaxAddresses;
+            // Use symmetric active association mode. This device may provide synchronization to the configured NTP server.
+            bool peer;
+            //	This is the minimum polling interval, in seconds to the power of two, 
+            //  allowed by any peer of the Internet system, currently set to 6 (64 seconds).
+            uint32_t minPoll;
+            // This is the maximum polling interval, in seconds to the power of two, 
+            // allowed by any peer of the Internet system, currently set to 10 (1024 seconds)
+            uint32_t maxPoll;
+            // If the IBurst parameter is enabled, and this is the first packet sent when 
+            // the server has been unreachable, the client sends a burst. This is useful to 
+            // quickly reduce the synchronization distance below the distance threshold and synchronize the clock. 
+            bool iBurst;
+            // If the Burst parameter is enabled and the server is reachable and 
+            // a valid source of synchronization is available, the client sends a 
+            // burst of BCOUNT (8) packets at each poll interval. The interval between packets 
+            // in the burst is two seconds. This is useful to accurately measure jitter with long poll intervals. [RFC5905].
+            uint32_t burst;
+            // The IP Interface associated with the Client entry.
+            std::string interface;
+            // Specifies how the client sockets are bound.
+            // Address (The client sockets are bound to a local IP address)
+            // Device (The client sockets are bound to a network device. This can be useful when the local address is dynamic)
+            std::string bindType;
+        };
         struct EXTERNAL INotification : virtual public Core::IUnknown {
             enum { ID = ID_TIMESYNC_NOTIFICATION };
 
@@ -38,6 +96,9 @@ namespace Exchange {
 
         virtual void Register(INotification* notification) = 0;
         virtual void Unregister(INotification* notification) = 0;
+
+        virtual uint32_t GetStatus(TSStatus &status /*out*/ ) const = 0;
+        virtual uint32_t SetConfiguration(const TimeSyncConfiguration &config, TSErrorDetail &status/* @out */) = 0;
 
         virtual uint32_t Synchronize() = 0;
         virtual void Cancel() = 0;

--- a/interfaces/ITimeSync.h
+++ b/interfaces/ITimeSync.h
@@ -97,7 +97,7 @@ namespace Exchange {
         virtual void Register(INotification* notification) = 0;
         virtual void Unregister(INotification* notification) = 0;
 
-        virtual uint32_t GetStatus(TSStatus &status /*out*/ );
+        virtual uint32_t GetStatus(TSStatus &status /*@out*/ );
         virtual uint32_t SetConfiguration(const TimeSyncConfiguration &config, TSErrorDetail &status/* @out */);
 
         virtual uint32_t Synchronize() = 0;


### PR DESCRIPTION
Adding new interfaces for getting time sync status and setting time configuration based on tr-181 Device:2.Device.Time.

1. GetStatus - Interface to get ntp sync status . TSStatus is the enum to get status
2. SetConfiguration - Interface to set tr-181 Device:2.Device.Time. TimeSyncConfiguration is the input configuration