### PR TITLE
updating ipv4 start and end address variables

### DIFF
--- a/interfaces/ILANControl.h
+++ b/interfaces/ILANControl.h
@@ -77,8 +77,8 @@ namespace Exchange {
             string netMask;
             /*IStringIterator ipv6Addresses;*/ // Iterator type is not supported in struct
             string ipv6Addresses;
-            string ipv4RangeStart;
-            string ipv4RangeEnd;
+            string ipv4StartAddress;
+            string ipv4EndAddress;
             IPv6AddressAssignmentMode ipv6AddressAssignmentMode;
             string ipv6ULA;
             string ipv6RangeStart;


### PR DESCRIPTION
IPv4RangeEnd variable has some issue . So using new variable names for start and end addresses